### PR TITLE
Change Dart wrapper to the actively developed fork

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,10 +281,10 @@
                     <small>by <span>xy137</span> &bull; <span>NodeJS</span></small>
                 </div>
             </a>
-            <a href="https://github.com/charafau/jikan-dart" class="wrapper" style="background:#00B4AB;" target="_blank">
+            <a href="https://github.com/javoeria/jikan-dart" class="wrapper" style="background:#00B4AB;" target="_blank">
                 <div>
-                    <h4><strong>Jikan-dart</strong></h4>
-                    <small>by <span>Rafal Wachol</span> &bull; <span>Dart</span></small>
+                    <h4><strong>jikan_api</strong></h4>
+                    <small>by <span>Javier Rosales</span> &bull; <span>Dart</span></small>
                 </div>
             </a>
             <a href="https://github.com/Julien-Broyard/jikants" class="wrapper invert" style="background: #F0DB4F;" target="_blank">


### PR DESCRIPTION
@charafau 's [jikan-dart](https://github.com/charafau/jikan-dart) wrapper seems to be no longer developed. (Last commit by the maintainer on Mar 17, 2019, last community contribution on Jun 25, 2019, merged on Dec 10, 2019)

@javoeria seems to be actively working on a fork of his project, called [jikan_api](https://pub.dev/packages/jikan_api) in the pub.dev (Dart package manager). (Last commit: Jun 12, 2020) Also, it seems that it's a lot more popular on pub.dev than the original jikan-dart wrapper.

Here's the link to his repo: [link](https://github.com/javoeria/jikan-dart)
