### PR TITLE
Fixed the OpenAPI hyperlink not linking to anything

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -511,7 +511,7 @@
 
 					<div>
 						<h6>OpenAPI 3.1 Specifications</h6>
-						<p>Generate wrappers on the fly as our documentation is built on <Button type="link" url="#" urlTarget="blank">OpenAPI 3.1</Button> Specs.</p>
+						<p>Generate wrappers on the fly as our documentation is built on <Button type="link" url="https://raw.githubusercontent.com/jikan-me/jikan-rest/master/storage/api-docs/api-docs.json" urlTarget="blank">OpenAPI 3.1</Button> Specs.</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Hi, I found this issue (#129) that states about the "OpenAPI" hyperlink on the page not linking to any Open API spec like the description before it says so. I decided to fix that by linking to the open api spec url that the jikan documentation site links to `(https://raw.githubusercontent.com/jikan-me/jikan-rest/master/storage/api-docs/api-docs.json)`.

Closes #129 