### PR TITLE
chore: update Jikan integration GitHub URL

### DIFF
--- a/src/data/integrations.js
+++ b/src/data/integrations.js
@@ -191,10 +191,10 @@ export default [
     {
         type: "Wrapper",
         author: "Sidharth Singh",
-        title: "Jikan-rs",
+        title: "Jikan_moe",
         language: "rust",
         supportsV3: false,
         supportsV4: true,
-        url: "https://github.com/Sidharth-Singh10/jikan-rs",
+        url: "https://github.com/Sidharth-Singh10/jikan_moe",
     },
 ]


### PR DESCRIPTION
The previous URL was outdated.
The PR updates the GitHub repository URL used for the Jikan integration to point to the updated source. 