### PR TITLE
Add Anime Filler Checker to showcase

### DIFF
--- a/src/data/showcase.js
+++ b/src/data/showcase.js
@@ -569,4 +569,10 @@ export default [
       imageUrl: "https://shinakamana.vercel.app/screenshot.png",
       url: "https://shinakamana.vercel.app/",
     },
+    {
+      title: "Anime Filler Checker",
+      summary: "Browser extension that auto-detects anime on streaming sites, shows filler/canon badges, and enriches episode info with MAL data via Jikan API.",
+      imageUrl: "https://animefillerchecker.com/promo-showcase.jpg",
+      url: "https://animefillerchecker.com"
+    },
 ]


### PR DESCRIPTION
## Add Anime Filler Checker to Showcase

**Anime Filler Checker** is a browser extension (Chrome & Firefox) that auto-detects anime and episode numbers on streaming sites like Crunchyroll, and displays filler/canon badges directly on the page.

It uses **Jikan API** to enrich episode data with MAL scores, member counts, and direct MAL links.

### Features
- Auto-detection of anime & episode from streaming site URLs
- Filler/Canon/Mixed-Canon badge overlay
- MAL score & member count via Jikan API
- Watch history tracking
- Streaming site whitelist
- Badge customization

### Links
- Website: https://animefillerchecker.com
- Chrome: https://chromewebstore.google.com/detail/anime-filler-checker
- Firefox: https://addons.mozilla.org/en-US/firefox/addon/anime-filler-checker/