### PR TITLE
feat: Add Anime Collection to showcase

### DIFF
--- a/src/data/showcase.js
+++ b/src/data/showcase.js
@@ -589,7 +589,7 @@ export default [
     },
     {
       title: 'Anime Collection',
-      summary: 'A feature-rich anime portal with Jikan API integration for rich metadata, reviews, and forums. Features include MAL bi-directional sync, watch history tracking, and seamless marathon playback.',
+      summary: 'A sophisticated, pure client-side anime portal tailored for the Indonesian community. Powered by Jikan, it features bi-directional MAL sync, watch history tracking, and seamless marathon playback in a zero-backend environment.',
       imageUrl: 'https://animeid.pages.dev/image/site.jpg',
       url: 'https://animeid.pages.dev'
     },

--- a/src/data/showcase.js
+++ b/src/data/showcase.js
@@ -504,7 +504,7 @@ export default [
         url: "https://mymediatracker.vercel.app/",
     }, 
     {
-        title: "AniHaven🎌",
+        title: "AniHaven\ud83c\udf8c",
         summary: "An anime discovery app with recommendations for newbies",
         imageUrl: "https://portfolio-pi-seven-48.vercel.app/assets/home-GgO_fKTe.png",
         url: "https://creeksonjoseph.github.io/AniHaven/",
@@ -586,5 +586,11 @@ export default [
       summary: "Your personal space to track, organize, and discover anime. Keep control of everything you watch.",
       imageUrl: "https://sorai-app.vercel.app/images/preview.png",
       url: "https://sorai-app.vercel.app/"
+    },
+    {
+      title: 'Anime Collection',
+      summary: 'A feature-rich anime portal with Jikan API integration for rich metadata, reviews, and forums. Features include MAL bi-directional sync, watch history tracking, and seamless marathon playback.',
+      imageUrl: 'https://animeid.pages.dev/image/site.jpg',
+      url: 'https://animeid.pages.dev'
     },
 ]


### PR DESCRIPTION
## Description
I would like to submit my project, **Anime Collection**, to be featured in the Jikan API showcase. 

**Anime Collection** is a sophisticated, **purely static (client-side)** anime portal designed for the Indonesian community. It utilizes the Jikan API as its primary engine for rich metadata, providing users with a comprehensive experience that includes synopses, reviews, forum discussions, and recommendations directly within the interface.

### Technical & Community Highlights:
*   **Zero-Backend Architecture:** Demonstrates the robustness of the Jikan API by handling complex state management, bi-directional MAL synchronization, and sequel-chain tracking entirely on the client side.
*   **Indonesian Community Focused:** Specifically tailored for the massive Indonesian anime community, featuring localized metadata rendering and specialized tracking for regional content.
*   **Bi-directional MAL Sync:** Features a sophisticated sync system with MyAnimeList using a stateless Google Apps Script proxy to bypass CORS while keeping user data private.
*   **Advanced Playback:** Includes a custom player logic with marathon mode and session-based watch history tracking.

### Showcase Entry:
```javascript
{
  title: 'Anime Collection',
  summary: 'A sophisticated, pure client-side anime portal tailored for the Indonesian community. Powered by Jikan, it features bi-directional MAL sync, watch history tracking, and seamless marathon playback in a zero-backend environment.',
  imageUrl: 'https://animeid.pages.dev/image/site.jpg',
  url: 'https://animeid.pages.dev'
}
```

## Related Issues
N/A

## Checklist
- [x] I have added my project to the `src/data/showcase.js` file.
- [x] The `imageUrl` points to a valid screenshot of the application.
- [x] The `url` is a functional live link to the project.